### PR TITLE
feat: add categories for lists

### DIFF
--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\ViewModels\User\ListViewModel;
+use App\Models\ListCategory;
 use App\Services\CreateList;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
@@ -21,6 +22,19 @@ class ListController extends Controller
         ]);
     }
 
+    public function new(): View
+    {
+        $listCategories = ListCategory::all()
+            ->map(fn (ListCategory $listCategory) => [
+                'id' => $listCategory->id,
+                'name' => $listCategory->name,
+            ]);
+
+        return view('user.lists.new', [
+            'listCategories' => $listCategories,
+        ]);
+    }
+
     public function store(Request $request): RedirectResponse
     {
         $list = (new CreateList(
@@ -29,6 +43,7 @@ class ListController extends Controller
             isPublic: false,
             canBeModified: true,
             gender: $request->input('gender'),
+            categoryId: $request->input('category'),
         ))->execute();
 
         Cache::forget('route-list-' . $list->id);
@@ -87,11 +102,6 @@ class ListController extends Controller
         Cache::forget('list-details-' . $list->id);
 
         return Redirect::route('list.index');
-    }
-
-    public function new(): View
-    {
-        return view('user.lists.new');
     }
 
     public function delete(Request $request): View

--- a/app/Models/ListCategory.php
+++ b/app/Models/ListCategory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ListCategory extends Model
+{
+    use HasFactory;
+
+    protected $table = 'list_categories';
+
+    protected $fillable = [
+        'name',
+        'description',
+        'is_serious',
+    ];
+
+    protected $casts = [
+        'is_serious' => 'boolean',
+    ];
+
+    public function nameLists(): HasMany
+    {
+        return $this->hasMany(NameList::class);
+    }
+}

--- a/app/Models/NameList.php
+++ b/app/Models/NameList.php
@@ -27,6 +27,7 @@ class NameList extends Model
         'can_be_modified',
         'is_list_of_favorites',
         'gender',
+        'list_category_id',
     ];
 
     protected $casts = [

--- a/app/Services/CreateList.php
+++ b/app/Services/CreateList.php
@@ -15,6 +15,7 @@ class CreateList extends BaseService
         public bool $isPublic,
         public bool $canBeModified,
         public string $gender,
+        public ?int $categoryId,
     ) {
     }
 
@@ -35,6 +36,7 @@ class CreateList extends BaseService
             'is_public' => $this->isPublic,
             'can_be_modified' => $this->canBeModified,
             'gender' => $this->gender,
+            'list_category_id' => $this->categoryId,
         ]);
     }
 }

--- a/database/factories/ListCategoryFactory.php
+++ b/database/factories/ListCategoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ListCategory>
+ */
+class ListCategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'description' => fake()->text(),
+            'is_serious' => fake()->boolean,
+        ];
+    }
+}

--- a/database/migrations/2024_02_19_131442_create_list_categories_table.php
+++ b/database/migrations/2024_02_19_131442_create_list_categories_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('list_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+
+
+    }
+};

--- a/database/migrations/2024_02_19_131442_create_list_categories_table.php
+++ b/database/migrations/2024_02_19_131442_create_list_categories_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -12,9 +13,55 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->text('description')->nullable();
+            $table->boolean('is_serious')->default(true);
             $table->timestamps();
         });
 
+        Schema::table('lists', function (Blueprint $table) {
+            $table->unsignedBigInteger('list_category_id')->after('user_id')->nullable();
+            $table->foreign('list_category_id')->references('id')->on('list_categories')->onDelete('cascade');
+        });
 
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms d\'origine religieuse',
+            'description' => 'En quête d\'un prénom empreint de spiritualité et d\'histoire ? Laissez-vous guider par notre sélection de prénoms d\'origine religieuse ! Des prénoms bibliques aux noms inspirés des grandes figures spirituelles, découvrez une source d\'inspiration infinie pour trouver le prénom parfait pour votre petit trésor.',
+            'is_serious' => true,
+        ]);
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms d\'origine géographique',
+            'description' => 'Partez à l\'aventure avec notre sélection de prénoms d\'origine géographique ! Des noms évoquant des paysages grandioses aux prénoms inspirés des plus belles villes du monde, découvrez une source d\'inspiration inédite pour trouver le prénom parfait pour votre petit explorateur.',
+            'is_serious' => true,
+        ]);
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms d\'origine historique',
+            'description' => 'Donnez à votre enfant un prénom qui traverse les siècles avec notre sélection de prénoms d\'origine historique ! Des figures légendaires aux personnages illustres, découvrez une source d\'inspiration unique pour trouver le prénom parfait pour votre petit prince ou votre petite princesse.',
+            'is_serious' => true,
+        ]);
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms inspirés de la nature',
+            'description' => 'Célébrez la beauté et la puissance de la nature en choisissant un prénom inspiré de ses éléments pour votre enfant ! Des fleurs délicates aux arbres majestueux, en passant par les animaux fascinants et les forces élémentaires, découvrez une source d\'inspiration infinie pour trouver le prénom parfait pour votre petit être.',
+            'is_serious' => true,
+        ]);
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms inspirés de la littérature et du cinéma',
+            'description' => 'Donnez vie à vos personnages préférés en choisissant un prénom inspiré de la littérature et du cinéma pour votre enfant ! Des héros inoubliables aux héroïnes courageuses, en passant par les créatures fantastiques et les personnages attachants, découvrez une source d\'inspiration inédite pour trouver le prénom parfait pour votre petit bout de chou.',
+            'is_serious' => true,
+        ]);
+
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms inventés',
+            'description' => 'Laissez libre cours à votre imagination et explorez le monde infini des prénoms inventés pour trouver le nom parfait pour votre enfant ! Des jeux vidéo aux univers fictifs, en passant par les gourmandises et les jeux de mots, découvrez une source d\'inspiration inédite pour créer un prénom unique et original qui correspond à votre personnalité et à vos rêves.',
+            'is_serious' => false,
+        ]);
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms à double sens',
+            'description' => 'Ajoutez une touche d\'originalité et de mystère au prénom de votre enfant en choisissant un nom à double sens ! Des prénoms qui changent de genre aux noms qui cachent des messages cachés, découvrez une source d\'inspiration inédite pour trouver le prénom parfait pour votre petit être.',
+            'is_serious' => false,
+        ]);
+        DB::table('list_categories')->insert([
+            'name' => 'Prénoms de célébrités',
+            'description' => 'Donnez à votre enfant le prénom d\'une célébrité que vous admirez pour lui transmettre votre passion et lui inspirer des valeurs de réussite, de talent et de persévérance ! Des acteurs légendaires aux chanteurs talentueux, en passant par les sportifs de haut niveau, découvrez une source d\'inspiration infinie pour trouver le prénom parfait pour votre petit bout de chou.',
+            'is_serious' => false,
+        ]);
     }
 };

--- a/resources/views/user/lists/new.blade.php
+++ b/resources/views/user/lists/new.blade.php
@@ -57,7 +57,7 @@
         </div>
 
         <!-- is public -->
-        <div class="relative px-6 pt-4 pb-4">
+        <div class="relative px-6 pt-4 pb-2">
           <p class="block font-medium text-sm text-gray-700 dark:text-gray-300">{{ __('Genre de la liste') }}</p>
           <div class="grid grid-flow-row sm:grid-flow-col sm:grid-cols-3 gap-4 pt-2 pb-4">
             <div class="flex p-3 ps-4 border border-gray-200 rounded dark:border-gray-700">
@@ -89,6 +89,19 @@
             </div>
           </div>
         </div>
+
+        @if (auth()->user()->is_administrator)
+        <div class="relative px-6 pt-4 pb-4">
+        <label for="country" class="block text-sm font-medium leading-6 text-gray-900">Catégories (pour administrateur seulement)</label>
+          <div class="mt-2">
+            <select id="category" name="category" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6">
+              @foreach ($listCategories as $category)
+                <option value="{{ $category['id'] }}">{{ $category['name'] }}</option>
+              @endforeach
+            </select>
+          </div>
+        </div>
+        @endif
 
         <!-- actions -->
         <div class="flex items-center justify-between border-t dark:border-gray-600 bg-white dark:bg-gray-800 px-6 py-4">

--- a/tests/Unit/Models/ListCategoryTest.php
+++ b/tests/Unit/Models/ListCategoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\ListCategory;
+use App\Models\Name;
+use App\Models\NameList;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ListCategoryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_has_many_list_names(): void
+    {
+        $listCategory = ListCategory::factory()->create();
+        $nameList = NameList::factory()->create([
+           'list_category_id' => $listCategory->id,
+        ]);
+
+        $this->assertTrue($listCategory->nameLists()->exists());
+    }
+}


### PR DESCRIPTION
This PR adds the notion of categories for lists.

This will be used to display a page of lists, sorted by categories.

An administrator sees this on the creation page of a list:

<img width="773" alt="image" src="https://github.com/monicahq/touslesprenoms/assets/61099/eb69f158-ad04-44d4-9b42-8c9dd850d757">
