### PR TITLE
feat: record page view for names

### DIFF
--- a/app/Http/Controllers/NameController.php
+++ b/app/Http/Controllers/NameController.php
@@ -6,6 +6,7 @@ use App\Http\ViewModels\Names\AllNamesViewModel;
 use App\Http\ViewModels\Names\NameViewModel;
 use App\Http\ViewModels\User\ListViewModel;
 use App\Http\ViewModels\User\UserViewModel;
+use App\Jobs\IncrementPageViewForName;
 use App\Models\Name;
 use App\Services\ToggleNameToNameList;
 use Illuminate\Contracts\View\View;
@@ -64,6 +65,8 @@ class NameController extends Controller
             $lists = ListViewModel::lists($requestedName);
             $note = $requestedName->getNoteForUser();
         }
+
+        IncrementPageViewForName::dispatch($requestedName->id);
 
         return view('names.show', [
             'name' => $name,

--- a/app/Jobs/IncrementPageViewForName.php
+++ b/app/Jobs/IncrementPageViewForName.php
@@ -2,7 +2,6 @@
 
 namespace App\Jobs;
 
-use App\Models\Name;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -16,7 +15,8 @@ class IncrementPageViewForName implements ShouldQueue
 
     public function __construct(
         public int $nameId
-    ) { }
+    ) {
+    }
 
     public function handle(): void
     {

--- a/app/Jobs/IncrementPageViewForName.php
+++ b/app/Jobs/IncrementPageViewForName.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Name;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class IncrementPageViewForName implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public int $nameId
+    ) { }
+
+    public function handle(): void
+    {
+        // we use the DB facade and not the model for performance reasons
+        // if we call the model inside the job, the model will be serialized
+        // and will consume resources. we don't need to serialize the model for
+        // this operation.
+        DB::table('names')
+            ->where('id', $this->nameId)
+            ->increment('page_views');
+    }
+}

--- a/tests/Unit/Jobs/IncrementPageViewForNameTest.php
+++ b/tests/Unit/Jobs/IncrementPageViewForNameTest.php
@@ -3,10 +3,7 @@
 namespace Tests\Unit\Jobs;
 
 use App\Jobs\IncrementPageViewForName;
-use App\Jobs\RecordTopicView;
-use App\Models\Channel;
 use App\Models\Name;
-use App\Models\Topic;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 

--- a/tests/Unit/Jobs/IncrementPageViewForNameTest.php
+++ b/tests/Unit/Jobs/IncrementPageViewForNameTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\IncrementPageViewForName;
+use App\Jobs\RecordTopicView;
+use App\Models\Channel;
+use App\Models\Name;
+use App\Models\Topic;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class IncrementPageViewForNameTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_increments_the_page_view_for_a_name(): void
+    {
+        $name = Name::factory()->create();
+
+        IncrementPageViewForName::dispatch($name->id);
+
+        $this->assertDatabaseHas('names', [
+            'id' => $name->id,
+            'page_views' => 2,
+        ]);
+    }
+}


### PR DESCRIPTION
This is executed as a job.
Every visit on a name triggers this job.
Eventually, we'll offer the possibility for users to browse the names per popularity.